### PR TITLE
Switch to Telegram Webhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ src/
 ```
 BOT_NAME=your_bot_name
 BOT_TOKEN=your_bot_token
+WEBHOOK_URL=https://your-domain.com/bot
+WEBHOOK_PATH=/bot
 DATABASE_URL=postgresql://user:password@host:5432/database
 PORT=8080
 SPRING_PROFILES_ACTIVE=prod

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,15 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-jdbc</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.springframework.retry</groupId>
+            <artifactId>spring-retry</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-aspects</artifactId>
+        </dependency>
         
         <!-- Cache -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,10 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-cache</artifactId>
         </dependency>
 

--- a/src/main/java/com/ua/yushchenko/PredictionsApplication.java
+++ b/src/main/java/com/ua/yushchenko/PredictionsApplication.java
@@ -3,6 +3,8 @@ package com.ua.yushchenko;
 import io.github.cdimascio.dotenv.Dotenv;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.retry.annotation.EnableRetry;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 /**
  * Main application class for the Predictions Telegram Bot.
@@ -11,6 +13,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
  * @author AI
  * @version 0.1-beta
  */
+@EnableRetry
+@EnableAsync
 @SpringBootApplication
 public class PredictionsApplication {
 

--- a/src/main/java/com/ua/yushchenko/config/BotConfig.java
+++ b/src/main/java/com/ua/yushchenko/config/BotConfig.java
@@ -27,6 +27,8 @@ public class BotConfig {
         BotSettings settings = new BotSettings();
         settings.setName(dotenv.get("BOT_NAME"));
         settings.setToken(dotenv.get("BOT_TOKEN"));
+        settings.setWebhookPath(dotenv.get("WEBHOOK_PATH"));
+        settings.setWebhookUrl(dotenv.get("WEBHOOK_URL"));
         return settings;
     }
 
@@ -38,5 +40,7 @@ public class BotConfig {
     public static class BotSettings {
         private String name;
         private String token;
+        private String webhookPath;
+        private String webhookUrl;
     }
-} 
+}

--- a/src/main/java/com/ua/yushchenko/config/BotConfig.java
+++ b/src/main/java/com/ua/yushchenko/config/BotConfig.java
@@ -28,7 +28,7 @@ public class BotConfig {
         settings.setName(dotenv.get("BOT_NAME"));
         settings.setToken(dotenv.get("BOT_TOKEN"));
         settings.setWebhookPath(dotenv.get("WEBHOOK_PATH"));
-        settings.setWebhookUrl(dotenv.get("WEBHOOK_URL"));
+        settings.setWebhookUrl(dotenv.get("TELEGRAM_BOT_WEB_HOOK_URL"));
         return settings;
     }
 

--- a/src/main/java/com/ua/yushchenko/config/BotInitializer.java
+++ b/src/main/java/com/ua/yushchenko/config/BotInitializer.java
@@ -46,11 +46,8 @@ public class BotInitializer {
     public TelegramBotsApi telegramBotsApi() throws TelegramApiException {
         TelegramBotsApi telegramBotsApi = new TelegramBotsApi(DefaultBotSession.class);
         try {
-            SetWebhook setWebhook = SetWebhook.builder()
-                                             .url(botSettings.getWebhookUrl())
-                                             .build();
-            bot.setWebhook(setWebhook);
-            telegramBotsApi.registerBot(bot, setWebhook);
+            bot.setWebhook(setWebhookInstance());
+            telegramBotsApi.registerBot(bot, setWebhookInstance());
             log.info("Webhook registered at {}", botSettings.getWebhookUrl());
         } catch (TelegramApiException e) {
             log.error("Error occurred: " + e.getMessage());

--- a/src/main/java/com/ua/yushchenko/config/BotInitializer.java
+++ b/src/main/java/com/ua/yushchenko/config/BotInitializer.java
@@ -2,11 +2,13 @@
 package com.ua.yushchenko.config;
 
 import com.ua.yushchenko.bot.TelegramBot;
+import com.ua.yushchenko.config.BotConfig.BotSettings;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 import org.telegram.telegrambots.meta.TelegramBotsApi;
+import org.telegram.telegrambots.meta.api.methods.updates.SetWebhook;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
 import org.telegram.telegrambots.updatesreceivers.DefaultBotSession;
 
@@ -22,14 +24,16 @@ import org.telegram.telegrambots.updatesreceivers.DefaultBotSession;
 public class BotInitializer {
     /** The bot instance to be registered */
     private final TelegramBot bot;
+    private final BotSettings botSettings;
 
     /**
      * Creates a new BotInitializer instance.
      *
      * @param bot the bot instance to initialize
      */
-    public BotInitializer(TelegramBot bot) {
+    public BotInitializer(TelegramBot bot, BotSettings botSettings) {
         this.bot = bot;
+        this.botSettings = botSettings;
     }
 
     /**
@@ -42,9 +46,13 @@ public class BotInitializer {
     public void init() throws TelegramApiException {
         TelegramBotsApi telegramBotsApi = new TelegramBotsApi(DefaultBotSession.class);
         try {
-            telegramBotsApi.registerBot(bot);
+            SetWebhook setWebhook = SetWebhook.builder()
+                                             .url(botSettings.getWebhookUrl())
+                                             .build();
+            telegramBotsApi.registerBot(bot, setWebhook);
+            log.info("Webhook registered at {}", botSettings.getWebhookUrl());
         } catch (TelegramApiException e) {
             log.error("Error occurred: " + e.getMessage());
         }
     }
-} 
+}

--- a/src/main/java/com/ua/yushchenko/controller/WebhookController.java
+++ b/src/main/java/com/ua/yushchenko/controller/WebhookController.java
@@ -1,0 +1,21 @@
+package com.ua.yushchenko.controller;
+
+import com.ua.yushchenko.bot.TelegramBot;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
+import org.telegram.telegrambots.meta.api.objects.Update;
+
+@RestController
+@RequiredArgsConstructor
+public class WebhookController {
+
+    private final TelegramBot telegramBot;
+
+    @PostMapping("${bot.webhook-path}")
+    public BotApiMethod<?> onUpdate(@RequestBody Update update) {
+        return telegramBot.onWebhookUpdateReceived(update);
+    }
+}

--- a/src/main/java/com/ua/yushchenko/controller/WebhookController.java
+++ b/src/main/java/com/ua/yushchenko/controller/WebhookController.java
@@ -14,7 +14,7 @@ public class WebhookController {
 
     private final TelegramBot telegramBot;
 
-    @PostMapping("${bot.webhook-path}")
+    @PostMapping("/callback${bot.webhook-path}")
     public BotApiMethod<?> onUpdate(@RequestBody Update update) {
         return telegramBot.onWebhookUpdateReceived(update);
     }

--- a/src/main/java/com/ua/yushchenko/service/telegram/TelegramApiExecutor.java
+++ b/src/main/java/com/ua/yushchenko/service/telegram/TelegramApiExecutor.java
@@ -19,8 +19,7 @@ public interface TelegramApiExecutor {
      * @param method the method to execute
      * @param <T> the type of the response
      * @param <Method> the type of the method
-     * @return the result of the method execution
      * @throws TelegramApiException if there is an error executing the method
      */
-    <T extends Serializable, Method extends BotApiMethod<T>> T execute(Method method) throws TelegramApiException;
+    <T extends Serializable, Method extends BotApiMethod<T>> void execute(Method method) throws TelegramApiException;
 } 

--- a/src/main/java/com/ua/yushchenko/service/telegram/TelegramApiExecutorImpl.java
+++ b/src/main/java/com/ua/yushchenko/service/telegram/TelegramApiExecutorImpl.java
@@ -5,6 +5,10 @@ import java.io.Serializable;
 import com.ua.yushchenko.bot.TelegramBot;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
 import org.telegram.telegrambots.meta.exceptions.TelegramApiException;
@@ -33,11 +37,17 @@ public class TelegramApiExecutorImpl implements TelegramApiExecutor {
      * @return the result of the method execution
      * @throws TelegramApiException if there is an error executing the method
      */
+    @Retryable(
+            value = { TelegramApiException.class },
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 2000) // 2 секунди між спробами
+    )
+    @Async
     @Override
-    public <T extends Serializable, Method extends BotApiMethod<T>> T execute(Method method) throws
+    public <T extends Serializable, Method extends BotApiMethod<T>> void execute(Method method) throws
             TelegramApiException {
         try {
-            return bot.execute(method);
+            bot.execute(method);
         } catch (TelegramApiException e) {
             if (e.getMessage().contains("message is not modified")) {
                 log.debug("Message is not modified");
@@ -46,5 +56,10 @@ public class TelegramApiExecutorImpl implements TelegramApiExecutor {
             log.error("Error executing method: {}", e.getMessage());
             throw e;
         }
+    }
+
+    @Recover
+    public void recover(TelegramApiException e, Long chatId, String messageText) {
+        log.warn("🔁 All retries failed for chatId {}. Message not sent: {}", chatId, messageText);
     }
 } 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,6 +4,8 @@ spring.main.allow-circular-references=true
 # Bot Configuration
 bot.name=${BOT_NAME}
 bot.token=${BOT_TOKEN}
+bot.webhook-path=${WEBHOOK_PATH:/bot}
+bot.webhook-url=${WEBHOOK_URL}
 
 # Database Configuration
 spring.datasource.url=${DATABASE_URL}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,7 +5,8 @@ spring.main.allow-circular-references=true
 bot.name=${BOT_NAME}
 bot.token=${BOT_TOKEN}
 bot.webhook-path=${WEBHOOK_PATH:/bot}
-bot.webhook-url=${WEBHOOK_URL}
+bot.webhook-url=${TELEGRAM_BOT_WEB_HOOK_URL}
+server.ssl.enabled=false
 
 # Database Configuration
 spring.datasource.url=${DATABASE_URL}


### PR DESCRIPTION
## Summary
- add webhook URL and path env vars to README
- configure webhook properties
- extend BotSettings with webhook parameters
- switch TelegramBot to use TelegramWebhookBot
- add controller to receive webhook updates
- auto-register webhook on startup

## Testing
- `./mvnw -q test` *(fails: cannot open ./.mvn/wrapper/maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_68403d2e218c832b83f6bd81d6b5d5f6